### PR TITLE
Made JSON for NER annotation valid

### DIFF
--- a/data/ner_annotations.json
+++ b/data/ner_annotations.json
@@ -116485,7 +116485,7 @@
           "flakes",
           "could",
           "exfoliate",
-          "and"
+          "and",
           "into",
           "graphene",
           "sheets",


### PR DESCRIPTION
There was a missing `,` delimiter on line `116488` in `data/ner_annotations.json`
